### PR TITLE
Use full led light intensity

### DIFF
--- a/src/LEDManager.cpp
+++ b/src/LEDManager.cpp
@@ -29,7 +29,7 @@
 #define LED_RAMP_MILLIS 50
 
 #define LEDC_MAX ((1u<<m_ledcBits)-1)
-#define MAX_BRIGHTNESS 0.10f // in percent
+#define MAX_BRIGHTNESS 1.00f // in percent
 
 
 namespace SlimeVR


### PR DESCRIPTION
## Description of the feature

The Trackers do not use the maximum intensity of the LEDs, I don't know if this is intentional or not.

In order to improve visibility, for example when charging, it would be interesting to use the maximum intensity of the LEDs.

Compared to battery usage, the cost of using LEDs at their maximum power is negligible and does not affect the Tracker's battery life.

## How to test it

Use the Trackers as usual (charging etc...), and see that the LED are more brighter.

## Checklist

Please check if your merge request fulfills the following requirements:

-   [X] Tests was made, and any changes were pushed.
-   [ ] Unit tests have been added, if needed.
-   [X] Branch has been rebased (see <https://git-scm.com/docs/git-rebase>) from the source branch.
-   [ ] Documentation has been updated, if needed.
-   [ ] Lint has passed, and most of the errors have been corrected, if possible.

/label ~Feature
