### PR TITLE
feat: reduce shutdown button press time to 100 milliseconds

### DIFF
--- a/src/ButtonMonitor.cpp
+++ b/src/ButtonMonitor.cpp
@@ -25,7 +25,7 @@
 #include "GlobalVars.h"
 #include "status/Status.h"
 
-#define SHUTDOWN_BUTTON_COUNT 100
+#define SHUTDOWN_BUTTON_COUNT 10
 #define FULL_OFF_BUTTON_COUNT 500
 
 namespace SlimeVR


### PR DESCRIPTION
## Description of the feature

Reduced shutdown button press countdown from 1 second to 100 milliseconds.

It's a minor improvement, but there's no reason why the countdown to turn off the Trackers should be so long. It's very unlikely that someone would accidentally press the button to turn off the Trackers (the button has no other use than to turn the Trackers on or off).

Reducing the time required to turn off the Trackers makes it easier to turn them off after a gaming session, especially when the user has a lot of Trackers and it takes a long time to turn them all off one by one.

## How to test it

When the Tracker is powered on, press the button to turn it off (not the full off, the one that take a long press for 5 seconds)

## Checklist

Please check if your merge request fulfills the following requirements:

-   [X] Tests was made, and any changes were pushed.
-   [ ] Unit tests have been added, if needed.
-   [X] Branch has been rebased (see <https://git-scm.com/docs/git-rebase>) from the source branch.
-   [ ] Documentation has been updated, if needed.
-   [ ] Lint has passed, and most of the errors have been corrected, if possible.

/label ~Feature
