### PR TITLE
Reduce complexity and improve performances

### DIFF
--- a/src/FSHelper.cpp
+++ b/src/FSHelper.cpp
@@ -65,7 +65,6 @@ void forEachFile(const char* directory, std::function<void(File file)> callback)
 		return;
 	}
 
-#ifdef ESP32
 	auto dir = LittleFS.open(directory);
 	while (auto f = dir.openNextFile()) {
 		if (f.isDirectory()) {
@@ -76,17 +75,6 @@ void forEachFile(const char* directory, std::function<void(File file)> callback)
 	}
 
 	dir.close();
-#else
-	auto dir = LittleFS.openDir(directory);
-	while (dir.next()) {
-		auto fd = dir.openFile("r");
-		if (!fd.isFile()) {
-			continue;
-		}
-
-		callback(File(fd));
-	}
-#endif
 }
 }  // namespace Utils
 }  // namespace SlimeVR

--- a/src/LEDManager.cpp
+++ b/src/LEDManager.cpp
@@ -36,13 +36,7 @@ namespace SlimeVR
 {
     void LEDManager::setup()
     {
-#if ENABLE_LEDS
-#if ESP32 && ENABLE_LEDC
-        ledcAttach(m_Pin, m_ledcFrequency, m_ledcBits);  // define the PWM Setup
-#else
-        pinMode(m_Pin, OUTPUT);
-#endif
-#endif
+        ledcAttachChannel(m_Pin, m_ledcFrequency, m_ledcBits, 5);  // define the PWM Setup
 
         // Do the initial pull of the state
         update();
@@ -50,24 +44,12 @@ namespace SlimeVR
 
     void LEDManager::on()
     {
-#if ENABLE_LEDS
-#if ESP32 && ENABLE_LEDC
         setBrightness((unsigned int) LEDC_MAX);
-#else
-        digitalWrite(m_Pin, LED__ON);
-#endif
-#endif
     }
 
     void LEDManager::off()
     {
-#if ENABLE_LEDS
-#if ESP32 && ENABLE_LEDC
         setBrightness((unsigned int)0);
-#else
-        digitalWrite(m_Pin, LED__OFF);
-#endif
-#endif
     }
 
     void LEDManager::blink(unsigned long time)
@@ -86,7 +68,6 @@ namespace SlimeVR
         }
     }
 
-#if ESP32 && ENABLE_LEDC
     void LEDManager::setBrightness(float percent)
     {        
         setBrightness( (unsigned int)(percent/100.0f * LEDC_MAX));
@@ -99,13 +80,8 @@ namespace SlimeVR
         if (brightness == m_CurrentBrightness)
             return;
         m_CurrentBrightness = brightness;
-#if LED_INVERTED
         // m_Logger.trace("Brightness set to %d. max is %d", LEDC_MAX - brightness, LEDC_MAX);
-        ledcWrite(m_Pin, LEDC_MAX - brightness * MAX_BRIGHTNESS);
-#else
-        // m_Logger.trace("Brightness set to %d. max is %d", brightness, LEDC_MAX);
-        ledcWrite(m_Pin, brightness * MAX_BRIGHTNESS);
-#endif        
+        ledcWrite(m_Pin, LEDC_MAX - brightness * MAX_BRIGHTNESS);     
     }
 
     void LEDManager::setRamp(float startPercent, float endPercent, unsigned long ms)
@@ -135,7 +111,6 @@ namespace SlimeVR
     {
         setRamp(m_CurrentBrightness, endBrightness, ms);
     }
-#endif
 
     void LEDManager::update()
     {
@@ -183,17 +158,14 @@ namespace SlimeVR
             case INTERVAL:
             case RAMP:
             case RAMP_CONTINUOUS:
-#if ESP32 && ENABLE_LEDC
                 rampFromCurrent(50.0f, 1000);
                 length = LED_RAMP_MILLIS;
-#endif
                 break;
             }
         }
         else if (statusManager.hasStatus(Status::BATTERY_CHARGING))
         {
             // m_Logger.info("Battery Charging: %d", m_CurrentStage);
-#if ESP32 && ENABLE_LEDC 
             switch (m_CurrentStage)
             {
             case ON:
@@ -207,7 +179,6 @@ namespace SlimeVR
                 length = LED_RAMP_MILLIS;
                 break;
             }
-#endif
         }
         else if (statusManager.hasStatus(Status::LOW_BATTERY))
         {
@@ -297,28 +268,6 @@ namespace SlimeVR
                 break;
             }
         }
-        // else if (statusManager.hasStatus(Status::SERVER_SEARCHING))
-        // {
-        //     count = SERVER_SEARCHING_COUNT;
-        //     switch (m_CurrentStage)
-        //     {
-        //     case ON:
-        //     case OFF:
-        //         length = SERVER_SEARCHING_LENGTH;
-        //         break;
-        //     case GAP:
-        //         length = DEFAULT_GAP;
-        //         break;
-        //     case INTERVAL:
-        //         length = SERVER_SEARCHING_INTERVAL;
-        //         break;
-        //     case RAMP:
-        //     case RAMP_CONTINUOUS:
-        //         m_CurrentStage = RAMP;
-        //         rampFromCurrent(0.0f,500);
-        //         break;
-        //     }
-        // }
         else
         {
 #if defined(LED_INTERVAL_STANDBY) && LED_INTERVAL_STANDBY > 0
@@ -378,7 +327,6 @@ namespace SlimeVR
                 m_CurrentStage = ON;
                 break;
             case RAMP:
-#if ESP32 && ENABLE_LEDC
                 // m_Logger.trace("RAMP: %d, %d, %d, %d", m_CurrentBrightness, m_rampDifference, m_rampStartBrightness, m_rampEndBrightness);
                 setBrightness(m_CurrentBrightness + m_rampDifference);
                 if (((m_rampDifference > 0) && (m_CurrentBrightness >= m_rampEndBrightness)) || 
@@ -396,7 +344,6 @@ namespace SlimeVR
                     m_rampEndBrightness = temp;
                     m_rampDifference = - m_rampDifference;
                 }
-#endif
                 break;
             }
         }

--- a/src/LEDManager.h
+++ b/src/LEDManager.h
@@ -68,13 +68,9 @@ namespace SlimeVR
 
     class LEDManager
     {
-    public:
-#if ESP32 && ENABLE_LEDC     
+    public: 
         LEDManager(uint8_t pin, int ledcFrequency = 5000, uint8_t ledcBits = 12) : 
                             m_Pin(pin), m_ledcFrequency(ledcFrequency), m_ledcBits(ledcBits), m_CurrentBrightness(0) {}
-#else
-        LEDManager(uint8_t pin) : m_Pin(pin) {}
-#endif
         void setup();
 
         /*!
@@ -86,14 +82,12 @@ namespace SlimeVR
          *  @brief Turns the LED off
          */
         void off();
-#if ESP32 && ENABLE_LEDC
         void setBrightness(float percent);
         void setBrightness(unsigned int brightness);
         void setRamp(float startPercent, float endPercent, unsigned long ms);
         void setRamp(unsigned int startBrightness, unsigned int endBrightness, unsigned long ms);
         void rampFromCurrent(float endPercent, unsigned long ms);
         void rampFromCurrent(unsigned int endBrightness, unsigned long ms);        
-#endif
         /*!
          *  @brief Blink the LED for [time]ms. *Can* cause lag
          *  @param time Amount of ms to turn the LED on
@@ -118,14 +112,12 @@ namespace SlimeVR
 
         uint8_t m_Pin;
         uint32_t m_LastStatus = 0;
-#if ESP32 && ENABLE_LEDC
         int m_ledcFrequency;
         uint8_t m_ledcBits;
         int m_rampDifference;
         unsigned int m_CurrentBrightness;
         unsigned int m_rampStartBrightness;
         unsigned int m_rampEndBrightness;
-#endif 
         Logging::Logger m_Logger = Logging::Logger("LEDManager");
     };
 }

--- a/src/batterymonitor.cpp
+++ b/src/batterymonitor.cpp
@@ -24,23 +24,7 @@
 
 #include "GlobalVars.h"
 
-#if ESP8266 \
-	&& (BATTERY_MONITOR == BAT_INTERNAL || BATTERY_MONITOR == BAT_INTERNAL_MCP3021)
-ADC_MODE(ADC_VCC);
-#endif
-
 void BatteryMonitor::Setup() {
-#if BATTERY_MONITOR == BAT_MCP3021 || BATTERY_MONITOR == BAT_INTERNAL_MCP3021
-	for (uint8_t i = 0x48; i < 0x4F; i++) {
-		if (I2CSCAN::hasDevOnBus(i)) {
-			address = i;
-			break;
-		}
-	}
-	if (address == 0) {
-		m_Logger.error("MCP3021 not found on I2C bus");
-	}
-#endif
 }
 
 void BatteryMonitor::Loop() {
@@ -49,49 +33,8 @@ void BatteryMonitor::Loop() {
 	auto now_ms = millis();
 	if (now_ms - last_battery_sample >= batterySampleRate) {
 		last_battery_sample = now_ms;
-		voltage = -1;
-#if ESP8266 \
-	&& (BATTERY_MONITOR == BAT_INTERNAL || BATTERY_MONITOR == BAT_INTERNAL_MCP3021)
-		// Find out what your max measurement is (voltage_3_3).
-		// Take the max measurement and check if it was less than 50mV
-		// if yes output 5.0V
-		// if no output 3.3V - dropvoltage + 0.1V
-		auto ESPmV = ESP.getVcc();
-		if (ESPmV > voltage_3_3) {
-			voltage_3_3 = ESPmV;
-		} else {
-			// Calculate drop in mV
-			ESPmV = voltage_3_3 - ESPmV;
-			if (ESPmV < 50) {
-				voltage = 5.0F;
-			} else {
-				voltage = 3.3F - ((float)ESPmV / 1000.0F)
-						+ 0.1F;  // we assume 100mV drop on the linear converter
-			}
-		}
-#endif
-#if ESP8266 && BATTERY_MONITOR == BAT_EXTERNAL
-		voltage = ((float)analogRead(PIN_BATTERY_LEVEL)) * ADCVoltageMax / ADCResolution
-				* ADCMultiplier;
-#endif
-#if ESP32 && BATTERY_MONITOR == BAT_EXTERNAL
 		voltage
 			= ((float)analogReadMilliVolts(PIN_BATTERY_LEVEL)) / 1000 * ADCMultiplier;
-#endif
-#if BATTERY_MONITOR == BAT_MCP3021 || BATTERY_MONITOR == BAT_INTERNAL_MCP3021
-		if (address > 0) {
-			Wire.beginTransmission(address);
-			Wire.requestFrom(address, (uint8_t)2);
-			auto MSB = Wire.read();
-			auto LSB = Wire.read();
-			auto status = Wire.endTransmission();
-			if (status == 0) {
-				float v = (((uint16_t)(MSB & 0x0F) << 6) | (uint16_t)(LSB >> 2));
-				v *= ADCMultiplier;
-				voltage = (voltage > 0) ? min(voltage, v) : v;
-			}
-		}
-#endif
 		if (voltage > 0)  // valid measurement
 		{
 			// Estimate battery level, 3.2V is 0%, 4.17V is 100% (1.0)

--- a/src/batterymonitor.h
+++ b/src/batterymonitor.h
@@ -30,10 +30,6 @@
 #include "globals.h"
 #include "logging/Logger.h"
 
-#if ESP8266
-#define ADCResolution 1023.0  // ESP8266 has 10bit ADC
-#define ADCVoltageMax 1.0  // ESP8266 input is 1.0 V = 1023.0
-#endif
 #ifndef ADCResolution
 #define ADCResolution 1023.0
 #endif

--- a/src/consts.h
+++ b/src/consts.h
@@ -166,13 +166,7 @@ enum class TrackerType : uint8_t {
 	TRACKER_TYPE_SVR_GLOVE_RIGHT
 };
 
-#ifdef ESP8266
-#define HARDWARE_MCU MCU_ESP8266
-#elif defined(ESP32)
 #define HARDWARE_MCU MCU_ESP32
-#else
-#define HARDWARE_MCU MCU_UNKNOWN
-#endif
 
 #define CURRENT_CONFIGURATION_VERSION 1
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -58,7 +58,7 @@
 #define samplingRateInMillis 10
 
 // Sleeping options
-#define POWERSAVING_MODE POWER_SAVING_LEGACY  // Minimum causes sporadic data pauses
+#define POWERSAVING_MODE POWER_SAVING_NONE  // Minimum causes sporadic data pauses
 #if POWERSAVING_MODE >= POWER_SAVING_MINIMUM
 #define TARGET_LOOPTIME_MICROS (samplingRateInMillis * 1000)
 #endif

--- a/src/defines.h
+++ b/src/defines.h
@@ -38,43 +38,8 @@
 #if BOARD != BOARD_GLOVE_IMU_SLIMEVR_DEV
 #define MAX_SENSORS_COUNT 1
 #define TRACKER_TYPE TrackerType::TRACKER_TYPE_SVR_ROTATION
-// Set I2C address here or directly in IMU_DESC_ENTRY for each IMU used
-// If not set, default address is used based on the IMU and Sensor ID
-// #define PRIMARY_IMU_ADDRESS_ONE 0x4a
-// #define SECONDARY_IMU_ADDRESS_TWO 0x4b
-
-// Axis mapping example
-/*
-#include "sensors/axisremap.h"
-#define BMI160_QMC_REMAP AXIS_REMAP_BUILD(AXIS_REMAP_USE_Y, AXIS_REMAP_USE_XN,
-AXIS_REMAP_USE_Z, \ AXIS_REMAP_USE_YN, AXIS_REMAP_USE_X, AXIS_REMAP_USE_Z)
-
-SENSOR_DESC_ENTRY(IMU_BMP160, PRIMARY_IMU_ADDRESS_ONE, IMU_ROTATION, PIN_IMU_SCL,
-PIN_IMU_SDA, PRIMARY_IMU_OPTIONAL, BMI160_QMC_REMAP) \
-*/
 
 #ifndef SENSOR_DESC_LIST
-#if BOARD == BOARD_SLIMEVR_V1_2
-#define SENSOR_DESC_LIST                                             \
-	SENSOR_DESC_ENTRY(                                               \
-		IMU,                                                         \
-		DIRECT_SPI(24'000'000, MSBFIRST, SPI_MODE3, DIRECT_PIN(15)), \
-		IMU_ROTATION,                                                \
-		NO_WIRE,                                                     \
-		PRIMARY_IMU_OPTIONAL,                                        \
-		DIRECT_PIN(PIN_IMU_INT),                                     \
-		0                                                            \
-	)                                                                \
-	SENSOR_DESC_ENTRY(                                               \
-		SECOND_IMU,                                                  \
-		SECONDARY_IMU_ADDRESS_TWO,                                   \
-		SECOND_IMU_ROTATION,                                         \
-		DIRECT_WIRE(PIN_IMU_SCL, PIN_IMU_SDA),                       \
-		SECONDARY_IMU_OPTIONAL,                                      \
-		DIRECT_PIN(PIN_IMU_INT_2),                                   \
-		0                                                            \
-	)
-#else
 #define SENSOR_DESC_LIST                       \
 	SENSOR_DESC_ENTRY(                         \
 		IMU,                                   \
@@ -96,138 +61,6 @@ PIN_IMU_SDA, PRIMARY_IMU_OPTIONAL, BMI160_QMC_REMAP) \
 	)
 #endif
 #endif
-#else
-
-// Predefines for the GLOVE
-#ifndef SENSOR_DESC_LIST
-#define MAX_SENSORS_COUNT 10
-#define TRACKER_TYPE TrackerType::TRACKER_TYPE_SVR_GLOVE_LEFT
-#define GLOVE_SIDE GLOVE_LEFT
-#define PRIMARY_IMU_ADDRESS_ONE 0x4a
-#define SECONDARY_IMU_ADDRESS_TWO 0x4b
-
-#define SENSOR_DESC_LIST                                 \
-	SENSOR_DESC_ENTRY(                                   \
-		IMU,                                             \
-		(PRIMARY_IMU_ADDRESS_ONE ^ 0x02),                \
-		IMU_ROTATION,                                    \
-		DIRECT_WIRE(PIN_IMU_SCL, PIN_IMU_SDA),           \
-		false,                                           \
-		MCP_PIN(MCP_GPA6),                               \
-		0                                                \
-	)                                                    \
-	SENSOR_DESC_ENTRY(                                   \
-		IMU,                                             \
-		(SECONDARY_IMU_ADDRESS_TWO ^ 0x02),              \
-		IMU_ROTATION,                                    \
-		DIRECT_WIRE(PIN_IMU_SCL, PIN_IMU_SDA),           \
-		true,                                            \
-		MCP_PIN(MCP_GPA5),                               \
-		0                                                \
-	)                                                    \
-	SENSOR_DESC_ENTRY(                                   \
-		IMU,                                             \
-		PRIMARY_IMU_ADDRESS_ONE,                         \
-		IMU_ROTATION,                                    \
-		PCA_WIRE(PIN_IMU_SCL, PIN_IMU_SDA, PCA_ADDR, 0), \
-		true,                                            \
-		MCP_PIN(MCP_GPB0),                               \
-		0                                                \
-	)                                                    \
-	SENSOR_DESC_ENTRY(                                   \
-		IMU,                                             \
-		SECONDARY_IMU_ADDRESS_TWO,                       \
-		IMU_ROTATION,                                    \
-		PCA_WIRE(PIN_IMU_SCL, PIN_IMU_SDA, PCA_ADDR, 0), \
-		true,                                            \
-		MCP_PIN(MCP_GPB1),                               \
-		0                                                \
-	)                                                    \
-	SENSOR_DESC_ENTRY(                                   \
-		IMU,                                             \
-		PRIMARY_IMU_ADDRESS_ONE,                         \
-		IMU_ROTATION,                                    \
-		PCA_WIRE(PIN_IMU_SCL, PIN_IMU_SDA, PCA_ADDR, 1), \
-		true,                                            \
-		MCP_PIN(MCP_GPB2),                               \
-		0                                                \
-	)                                                    \
-	SENSOR_DESC_ENTRY(                                   \
-		IMU,                                             \
-		SECONDARY_IMU_ADDRESS_TWO,                       \
-		IMU_ROTATION,                                    \
-		PCA_WIRE(PIN_IMU_SCL, PIN_IMU_SDA, PCA_ADDR, 1), \
-		true,                                            \
-		MCP_PIN(MCP_GPB3),                               \
-		0                                                \
-	)                                                    \
-	SENSOR_DESC_ENTRY(                                   \
-		IMU,                                             \
-		PRIMARY_IMU_ADDRESS_ONE,                         \
-		IMU_ROTATION,                                    \
-		PCA_WIRE(PIN_IMU_SCL, PIN_IMU_SDA, PCA_ADDR, 2), \
-		true,                                            \
-		MCP_PIN(MCP_GPB4),                               \
-		0                                                \
-	)                                                    \
-	SENSOR_DESC_ENTRY(                                   \
-		IMU,                                             \
-		SECONDARY_IMU_ADDRESS_TWO,                       \
-		IMU_ROTATION,                                    \
-		PCA_WIRE(PIN_IMU_SCL, PIN_IMU_SDA, PCA_ADDR, 2), \
-		true,                                            \
-		MCP_PIN(MCP_GPB5),                               \
-		0                                                \
-	)                                                    \
-	SENSOR_DESC_ENTRY(                                   \
-		IMU,                                             \
-		PRIMARY_IMU_ADDRESS_ONE,                         \
-		IMU_ROTATION,                                    \
-		PCA_WIRE(PIN_IMU_SCL, PIN_IMU_SDA, PCA_ADDR, 3), \
-		true,                                            \
-		MCP_PIN(MCP_GPB6),                               \
-		0                                                \
-	)                                                    \
-	SENSOR_DESC_ENTRY(                                   \
-		IMU,                                             \
-		SECONDARY_IMU_ADDRESS_TWO,                       \
-		IMU_ROTATION,                                    \
-		PCA_WIRE(PIN_IMU_SCL, PIN_IMU_SDA, PCA_ADDR, 3), \
-		true,                                            \
-		MCP_PIN(MCP_GPA1),                               \
-		0                                                \
-	)
-
-#if GLOVE_SIDE == GLOVE_LEFT
-#define SENSOR_INFO_LIST                                                    \
-	SENSOR_INFO_ENTRY(0, SensorPosition::POSITION_LEFT_HAND)                \
-	SENSOR_INFO_ENTRY(1, SensorPosition::POSITION_LEFT_LITTLE_INTERMEDIATE) \
-	SENSOR_INFO_ENTRY(2, SensorPosition::POSITION_LEFT_RING_INTERMEDIATE)   \
-	SENSOR_INFO_ENTRY(3, SensorPosition::POSITION_LEFT_RING_DISTAL)         \
-	SENSOR_INFO_ENTRY(4, SensorPosition::POSITION_LEFT_MIDDLE_INTERMEDIATE) \
-	SENSOR_INFO_ENTRY(5, SensorPosition::POSITION_LEFT_MIDDLE_DISTAL)       \
-	SENSOR_INFO_ENTRY(6, SensorPosition::POSITION_LEFT_INDEX_INTERMEDIATE)  \
-	SENSOR_INFO_ENTRY(7, SensorPosition::POSITION_LEFT_INDEX_DISTAL)        \
-	SENSOR_INFO_ENTRY(8, SensorPosition::POSITION_LEFT_THUMB_PROXIMAL)      \
-	SENSOR_INFO_ENTRY(9, SensorPosition::POSITION_LEFT_THUMB_DISTAL)
-#elif GLOVE_SIDE == GLOVE_RIGHT
-#define SENSOR_INFO_LIST                                                     \
-	SENSOR_INFO_ENTRY(0, SensorPosition::POSITION_RIGHT_HAND)                \
-	SENSOR_INFO_ENTRY(1, SensorPosition::POSITION_RIGHT_LITTLE_INTERMEDIATE) \
-	SENSOR_INFO_ENTRY(2, SensorPosition::POSITION_RIGHT_RING_INTERMEDIATE)   \
-	SENSOR_INFO_ENTRY(3, SensorPosition::POSITION_RIGHT_RING_DISTAL)         \
-	SENSOR_INFO_ENTRY(4, SensorPosition::POSITION_RIGHT_MIDDLE_INTERMEDIATE) \
-	SENSOR_INFO_ENTRY(5, SensorPosition::POSITION_RIGHT_MIDDLE_DISTAL)       \
-	SENSOR_INFO_ENTRY(6, SensorPosition::POSITION_RIGHT_INDEX_INTERMEDIATE)  \
-	SENSOR_INFO_ENTRY(7, SensorPosition::POSITION_RIGHT_INDEX_DISTAL)        \
-	SENSOR_INFO_ENTRY(8, SensorPosition::POSITION_RIGHT_THUMB_PROXIMAL)      \
-	SENSOR_INFO_ENTRY(9, SensorPosition::POSITION_RIGHT_THUMB_DISTAL)
-#else  // GLOVE_SDIE
-#error "Glove side not defined"
-#endif  // GLOVE_SDIE
-
-#endif  // SENSOR_DESC_LIST
-#endif  // BOARD != BOARD_GLOVE_IMU_SLIMEVR_DEV
 
 // Battery monitoring options (comment to disable):
 //   BAT_EXTERNAL for ADC pin,
@@ -235,220 +68,34 @@ PIN_IMU_SDA, PRIMARY_IMU_OPTIONAL, BMI160_QMC_REMAP) \
 //   BAT_MCP3021 for external ADC connected over I2C
 #define BATTERY_MONITOR BAT_EXTERNAL
 
-// BAT_EXTERNAL definition override
-// D1 Mini boards with ESP8266 have internal resistors. For these boards you only have
-// to adjust BATTERY_SHIELD_RESISTANCE. For other boards you can now adjust the other
-// resistor values. The diagram looks like this:
-//   (Battery)--- [BATTERY_SHIELD_RESISTANCE] ---(INPUT_BOARD)---  [BATTERY_SHIELD_R2]
-//   ---(ESP32_INPUT)--- [BATTERY_SHIELD_R1] --- (GND)
-// #define BATTERY_SHIELD_RESISTANCE 180 //130k BatteryShield, 180k SlimeVR or fill in
-// external resistor value in kOhm #define BATTERY_SHIELD_R1 100 // Board voltage
-// divider resistor Ain to GND in kOhm #define BATTERY_SHIELD_R2 220 // Board voltage
-// divider resistor Ain to INPUT_BOARD in kOhm
-
-// LED configuration:
-// Configuration Priority 1 = Highest:
-// 1. LED_PIN
-// 2. LED_BUILTIN
-//
-//   LED_PIN
-//     - Number or Symbol (D1,..) of the Output
-//     - To turn off the LED, set LED_PIN to LED_OFF
-//   LED_INVERTED
-//     - false for output 3.3V on high
-//     - true for pull down to GND on high
-
 // Board-specific configurations
-#if BOARD == BOARD_SLIMEVR
-#define PIN_IMU_SDA 14
-#define PIN_IMU_SCL 12
-#define PIN_IMU_INT 16
-#define PIN_IMU_INT_2 13
-#define PIN_BATTERY_LEVEL 17
-#define LED_PIN 2
-#define LED_INVERTED true
-#ifndef BATTERY_SHIELD_RESISTANCE
-#define BATTERY_SHIELD_RESISTANCE 0
-#endif
-#ifndef BATTERY_SHIELD_R1
-#define BATTERY_SHIELD_R1 10
-#endif
-#ifndef BATTERY_SHIELD_R2
-#define BATTERY_SHIELD_R2 40.2
-#endif
-#elif BOARD == BOARD_SLIMEVR_V1_2
-#define PIN_IMU_SDA 4
-#define PIN_IMU_SCL 5
-#define PIN_IMU_INT 2
-#define PIN_IMU_INT_2 16
-#define PIN_BATTERY_LEVEL 17
-#define LED_PIN 2
-#define LED_INVERTED true
-#ifndef BATTERY_SHIELD_RESISTANCE
-#define BATTERY_SHIELD_RESISTANCE 0
-#endif
-#ifndef BATTERY_SHIELD_R1
-#define BATTERY_SHIELD_R1 10
-#endif
-#ifndef BATTERY_SHIELD_R2
-#define BATTERY_SHIELD_R2 40.2
-#endif
-#elif BOARD == BOARD_SLIMEVR_LEGACY || BOARD == BOARD_SLIMEVR_DEV
-#define PIN_IMU_SDA 4
-#define PIN_IMU_SCL 5
-#define PIN_IMU_INT 10
-#define PIN_IMU_INT_2 13
-#define PIN_BATTERY_LEVEL 17
-#define LED_PIN 2
-#define LED_INVERTED true
-#ifndef BATTERY_SHIELD_RESISTANCE
-#define BATTERY_SHIELD_RESISTANCE 0
-#endif
-#ifndef BATTERY_SHIELD_R1
-#define BATTERY_SHIELD_R1 10
-#endif
-#ifndef BATTERY_SHIELD_R2
-#define BATTERY_SHIELD_R2 40.2
-#endif
-#elif BOARD == BOARD_NODEMCU || BOARD == BOARD_WEMOSD1MINI
-#define PIN_IMU_SDA D2
-#define PIN_IMU_SCL D1
-#define PIN_IMU_INT D5
-#define PIN_IMU_INT_2 D6
-#define PIN_BATTERY_LEVEL A0
-//  #define LED_PIN 2
-//  #define LED_INVERTED true
-#ifndef BATTERY_SHIELD_RESISTANCE
-#define BATTERY_SHIELD_RESISTANCE 180
-#endif
-#ifndef BATTERY_SHIELD_R1
-#define BATTERY_SHIELD_R1 100
-#endif
-#ifndef BATTERY_SHIELD_R2
-#define BATTERY_SHIELD_R2 220
-#endif
-#elif BOARD == BOARD_ESP01
-#define PIN_IMU_SDA 2
-#define PIN_IMU_SCL 0
-#define PIN_IMU_INT 255
-#define PIN_IMU_INT_2 255
-#define PIN_BATTERY_LEVEL 255
-#define LED_PIN LED_OFF
-#define LED_INVERTED false
-#elif BOARD == BOARD_TTGO_TBASE
-#define PIN_IMU_SDA 5
-#define PIN_IMU_SCL 4
-#define PIN_IMU_INT 14
-#define PIN_IMU_INT_2 13
-#define PIN_BATTERY_LEVEL A0
-//  #define LED_PIN 2
-//  #define LED_INVERTED false
-#elif BOARD == BOARD_CUSTOM
-// Define pins by the examples above
-#elif BOARD == BOARD_WROOM32
-#define PIN_IMU_SDA 21
-#define PIN_IMU_SCL 22
-#define PIN_IMU_INT 23
-#define PIN_IMU_INT_2 25
-#define PIN_BATTERY_LEVEL 36
-//  #define LED_PIN 2
-//  #define LED_INVERTED false
-#elif BOARD == BOARD_LOLIN_C3_MINI
-#define PIN_IMU_SDA 5
-#define PIN_IMU_SCL 4
-#define PIN_IMU_INT 6
-#define PIN_IMU_INT_2 8
-#define PIN_BATTERY_LEVEL 3
-#define LED_PIN 7
-//  #define LED_INVERTED false
-#elif BOARD == BOARD_BEETLE32C3
 #define PIN_IMU_SDA 8
-#define PIN_IMU_SCL 9
-#define PIN_IMU_INT 6
-#define PIN_IMU_INT_2 7
-#define PIN_BATTERY_LEVEL 3
-#define LED_PIN 10
-#define LED_INVERTED false
-#elif BOARD == BOARD_ESP32C3DEVKITM1 || BOARD == BOARD_ESP32C6DEVKITC1
-#define PIN_IMU_SDA 5
-#define PIN_IMU_SCL 4
-#define PIN_IMU_INT 6
-#define PIN_IMU_INT_2 7
-#define PIN_BATTERY_LEVEL 3
-#define LED_PIN \
-	LED_OFF  // RGB LED Protocol would need to be implementetet did not brother for the
-			 // test, because the board ideal for tracker ifself
-//  #define LED_INVERTED false
-#elif BOARD == BOARD_WEMOSWROOM02
-#define PIN_IMU_SDA 2
-#define PIN_IMU_SCL 14
-#define PIN_IMU_INT 0
-#define PIN_IMU_INT_2 4
-#define PIN_BATTERY_LEVEL A0
-#define LED_PIN 16
+#define PIN_IMU_SCL 7
+#define PIN_IMU_INT 5
+#define PIN_IMU_INT_2 255
+#define PIN_IMU_ENABLE 1
+#define PIN_CHRG_DONE 1
+#define PIN_BATTERY_LEVEL 0
+#define LED_PIN 9
 #define LED_INVERTED true
-#elif BOARD == BOARD_XIAO_ESP32C3
-#define PIN_IMU_SDA 6  // D4
-#define PIN_IMU_SCL 7  // D5
-#define PIN_IMU_INT 5  // D3
-#define PIN_IMU_INT_2 10  // D10
-#define LED_PIN 4  // D2
-#define LED_INVERTED false
-#define PIN_BATTERY_LEVEL 2  // D0 / A0
+#define LEDC_FREQ_LED 20000
+#define LEDC_BITS_LED  10  
+#define PIN_ENABLE_LATCH 2
+#define PIN_BUTTON_INPUT 3
+#define PIN_TACT_MOTOR 6
+#define LEDC_FREQ_TACT_MOTOR 20000
+#define LEDC_BITS_TACT_MOTOR  8
+#define PIN_USB_PD_INT 4
+#define PIN_CHARGER_INT 10
+#define PIN_BAT_STAT_CHRG 4
+#define PIN_BAT_STAT_CHRG_DONE 10
+#define TACT_MOTOR_MAX_V  3.0f
 #ifndef BATTERY_SHIELD_RESISTANCE
 #define BATTERY_SHIELD_RESISTANCE 0
 #endif
-#ifndef BATTERY_SHIELD_R1
-#define BATTERY_SHIELD_R1 100
-#endif
-#ifndef BATTERY_SHIELD_R2
-#define BATTERY_SHIELD_R2 100
-#endif
-#elif BOARD == BOARD_GLOVE_IMU_SLIMEVR_DEV
-#define PIN_IMU_SDA 1
-#define PIN_IMU_SCL 0
-#define PCA_ADDR 0x70
-#define PIN_IMU_INT 16
-#define PIN_IMU_INT_2 13
-#define PIN_BATTERY_LEVEL 3
-#define LED_PIN 2
-#define LED_INVERTED true
-#ifndef BATTERY_SHIELD_RESISTANCE
-#define BATTERY_SHIELD_RESISTANCE 0
-#endif
-#ifndef BATTERY_SHIELD_R1
+#ifndef BATTERY_SHIELD_R1 
 #define BATTERY_SHIELD_R1 10
 #endif
 #ifndef BATTERY_SHIELD_R2
-#define BATTERY_SHIELD_R2 40.2
-#endif
-#elif BOARD == BOARD_SOMATIC_EROS
-  #define PIN_IMU_SDA 8
-  #define PIN_IMU_SCL 7
-  #define PIN_IMU_INT 5
-  #define PIN_IMU_INT_2 255
-  #define PIN_IMU_ENABLE 1
-  #define PIN_CHRG_DONE 1
-  #define PIN_BATTERY_LEVEL 0
-  #define LED_PIN 9
-  #define LED_INVERTED true
-  #define LEDC_FREQ_LED 5000
-  #define LEDC_BITS_LED  12  
-  #define PIN_ENABLE_LATCH 2
-  #define PIN_BUTTON_INPUT 3
-  #define PIN_TACT_MOTOR 6
-  #define LEDC_FREQ_TACT_MOTOR 5000
-  #define LEDC_BITS_TACT_MOTOR  8
-  #define PIN_USB_PD_INT 4
-  #define PIN_CHARGER_INT 10
-  #define TACT_MOTOR_MAX_V  3.0f
-  #ifndef BATTERY_SHIELD_RESISTANCE
-    #define BATTERY_SHIELD_RESISTANCE 0
-  #endif
-  #ifndef BATTERY_SHIELD_R1 
-    #define BATTERY_SHIELD_R1 10
-  #endif
-  #ifndef BATTERY_SHIELD_R2
-    #define BATTERY_SHIELD_R2 45.3
-  #endif
+#define BATTERY_SHIELD_R2 45.3
 #endif

--- a/src/globals.h
+++ b/src/globals.h
@@ -31,50 +31,10 @@
 #include "defines_bmi160.h"
 #include "defines_sensitivity.h"
 
-#ifndef SECOND_IMU
-#define SECOND_IMU IMU
-#endif
-
-#ifndef SECOND_IMU_ROTATION
-#define SECOND_IMU_ROTATION IMU_ROTATION
-#endif
-
-#ifndef BATTERY_MONITOR
-#define BATTERY_MONITOR BAT_INTERNAL
-#endif
-
-// If LED_PIN is not defined in "defines.h" take the default pin from "pins_arduino.h"
-// framework. If there is no pin defined for the board, use LED_PIN 255 and disable LED
-#if defined(LED_PIN)
-// LED_PIN is defined
-#if (LED_PIN < 0) || (LED_PIN >= LED_OFF)
-#define ENABLE_LEDS false
-#else
 #define ENABLE_LEDS true
-#endif
-#else
-// LED_PIN is not defined
-#if defined(LED_BUILTIN) && (LED_BUILTIN < LED_OFF) && (LED_BUILTIN >= 0)
-#define LED_PIN LED_BUILTIN
-#define ENABLE_LEDS true
-#else
-#define LED_PIN LED_OFF
-#define ENABLE_LEDS false
-#endif
-#endif
 
-#if !defined(LED_INVERTED)
-// default is inverted for SlimeVR / ESP-12E
-#define LED_INVERTED true
-#endif
-
-#if LED_INVERTED
 #define LED__ON LOW
 #define LED__OFF HIGH
-#else
-#define LED__ON HIGH
-#define LED__OFF LOW
-#endif
 
 #ifndef SENSOR_INFO_LIST
 #define SENSOR_INFO_LIST

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,14 +90,12 @@ void setup() {
     pinMode(PIN_TACT_MOTOR, OUTPUT);
     digitalWrite(PIN_TACT_MOTOR, buttonMonitor.isPressed()?HIGH:LOW);
 #endif
-#ifdef ESP32C3
     // Wait for the Computer to be able to connect.
     delay(1000);
 #ifdef PIN_TACT_MOTOR
     digitalWrite(PIN_TACT_MOTOR, LOW);
 #endif
     delay(1000);
-#endif
 
 	Serial.begin(serialBaudRate);
 	globalTimer = timer_create_default();
@@ -125,19 +123,14 @@ void setup() {
 
 	// join I2C bus
 
-#if ESP32
 	// For some unknown reason the I2C seem to be open on ESP32-C3 by default. Let's
 	// just close it before opening it again. (The ESP32-C3 only has 1 I2C.)
 	Wire.end();
-#endif
 
 	// using `static_cast` here seems to be better, because there are 2 similar function
 	// signatures
 	Wire.begin(static_cast<int>(PIN_IMU_SDA), static_cast<int>(PIN_IMU_SCL));
 
-#ifdef ESP8266
-	Wire.setClockStretchLimit(150000L);  // Default stretch limit 150mS
-#endif
 #ifdef ESP32  // Counterpart on ESP32 to ClockStretchLimit
 	Wire.setTimeOut(150);
 #endif

--- a/src/network/wifihandler.cpp
+++ b/src/network/wifihandler.cpp
@@ -23,9 +23,7 @@
 #include "GlobalVars.h"
 #include "globals.h"
 #include "logging/Logger.h"
-#if !ESP8266
 #include "esp_wifi.h"
-#endif
 
 unsigned long lastWifiReportTime = 0;
 unsigned long wifiConnectionTimeout = millis();
@@ -75,13 +73,6 @@ void WiFiNetwork::setUp() {
     WiFi.hostname((hostname + String(mac[3]) + String(mac[4]) + String(mac[5])).c_str());
     WiFi.persistent(true);
     WiFi.mode(WIFI_STA);
-    #if ESP8266
-        #if USE_ATTENUATION
-	WiFi.setOutputPower(20.0 - ATTENUATION_N);
-        #endif
-    WiFi.setPhyMode(WIFI_PHY_MODE_11N);
-    #endif
-    #if ESP32
     esp_err_t espStatus = esp_wifi_set_max_tx_power(9.54*4); // argument is max dBm * 4
     int8_t power = 0;
     switch (espStatus)
@@ -103,7 +94,6 @@ void WiFiNetwork::setUp() {
         default:
             wifiHandlerLogger.debug("Failed to set max WiFi TX power. Reason: Unknown. error code: %04x", espStatus);
     }
-    #endif
     if (!WiFi.SSID().isEmpty())
         wifiHandlerLogger.info(
             "Loaded credentials for SSID '%s' and pass length %d",
@@ -128,18 +118,6 @@ void WiFiNetwork::setUp() {
     wifiState = SLIME_WIFI_SAVED_ATTEMPT;
     wifiConnectionTimeout = millis();
 
-#if ESP8266
-#if POWERSAVING_MODE == POWER_SAVING_NONE
-    WiFi.setSleepMode(WIFI_NONE_SLEEP);
-#elif POWERSAVING_MODE == POWER_SAVING_MINIMUM
-    WiFi.setSleepMode(WIFI_MODEM_SLEEP);
-#elif POWERSAVING_MODE == POWER_SAVING_MODERATE
-    WiFi.setSleepMode(WIFI_MODEM_SLEEP, 10);
-#elif POWERSAVING_MODE == POWER_SAVING_MAXIMUM
-    WiFi.setSleepMode(WIFI_LIGHT_SLEEP, 10);
-#error "MAX POWER SAVING NOT WORKING YET, please disable!"
-#endif
-#else
 #if POWERSAVING_MODE == POWER_SAVING_NONE
     WiFi.setSleep(WIFI_PS_NONE);
 #elif POWERSAVING_MODE == POWER_SAVING_MINIMUM
@@ -154,7 +132,6 @@ void WiFiNetwork::setUp() {
 	} else {
         wifiHandlerLogger.error("Unable to get WiFi config, power saving not enabled!");
     }
-#endif
 #endif
 }
 
@@ -187,43 +164,12 @@ void WiFiNetwork::upkeep() {
                 return;
 				case SLIME_WIFI_SAVED_ATTEMPT:  // Couldn't connect with first set of
 												// credentials
-                    #if ESP8266
-					// Try again but with 11G but only if there are credentials,
-					// otherwise we just waste time before switching to hardcoded
-					// credentials.
-                        if (WiFi.SSID().length() > 0) {
-                            #if USE_ATTENUATION
-						WiFi.setOutputPower(20.0 - ATTENUATION_G);
-                            #endif
-                            WiFi.setPhyMode(WIFI_PHY_MODE_11G);
-                            setStaticIPIfDefined();
-                            WiFi.begin();
-                            wifiConnectionTimeout = millis();
-						wifiHandlerLogger.error(
-							"Can't connect from saved credentials, status: %d.",
-							WiFi.status()
-						);
-						wifiHandlerLogger.debug(
-							"Trying saved credentials with PHY Mode G..."
-						);
-                        } else {
-						wifiHandlerLogger.debug(
-							"Skipping PHY Mode G attempt on 0-length SSID..."
-						);
-                        }
-                    #endif
                     wifiState = SLIME_WIFI_SAVED_G_ATTEMPT;
                 return;
 				case SLIME_WIFI_SAVED_G_ATTEMPT:  // Couldn't connect with first set of
 												  // credentials with PHY Mode G
                     #if defined(WIFI_CREDS_SSID) && defined(WIFI_CREDS_PASSWD)
                         // Try hardcoded credentials now
-                        #if ESP8266
-                            #if USE_ATTENUATION
-					WiFi.setOutputPower(20.0 - ATTENUATION_N);
-                            #endif
-                            WiFi.setPhyMode(WIFI_PHY_MODE_11N);
-                        #endif
                         setStaticIPIfDefined();
                         WiFi.begin(WIFI_CREDS_SSID, WIFI_CREDS_PASSWD);
                         wifiConnectionTimeout = millis();
@@ -237,51 +183,15 @@ void WiFiNetwork::upkeep() {
                 return;
 				case SLIME_WIFI_HARDCODE_ATTEMPT:  // Couldn't connect with second set
 												   // of credentials
-                    #if defined(WIFI_CREDS_SSID) && defined(WIFI_CREDS_PASSWD) && ESP8266
-												   // Try hardcoded credentials again,
-												   // but with PHY Mode G
-                        #if USE_ATTENUATION
-					WiFi.setOutputPower(20.0 - ATTENUATION_G);
-                        #endif
-                        WiFi.setPhyMode(WIFI_PHY_MODE_11G);
-                        setStaticIPIfDefined();
-                        WiFi.begin(WIFI_CREDS_SSID, WIFI_CREDS_PASSWD);
-                        wifiConnectionTimeout = millis();
-					wifiHandlerLogger.error(
-						"Can't connect from saved credentials, status: %d.",
-						WiFi.status()
-					);
-					wifiHandlerLogger.debug(
-						"Trying hardcoded credentials with WiFi PHY Mode G..."
-					);
-                    #endif
                     wifiState = SLIME_WIFI_HARDCODE_G_ATTEMPT;
                 return;
 				case SLIME_WIFI_SERVER_CRED_ATTEMPT:  // Couldn't connect with
 													  // server-sent credentials.
-                    #if ESP8266
-                        // Try again silently but with 11G
-                        #if USE_ATTENUATION
-					WiFi.setOutputPower(20.0 - ATTENUATION_G);
-                        #endif
-                        WiFi.setPhyMode(WIFI_PHY_MODE_11G);
-                        setStaticIPIfDefined();
-                        WiFi.begin();
-                        wifiConnectionTimeout = millis();
-                        wifiState = SLIME_WIFI_SERVER_CRED_G_ATTEMPT;
-                    #endif
                 return;
 				case SLIME_WIFI_HARDCODE_G_ATTEMPT:  // Couldn't connect with second set
 													 // of credentials with PHY Mode G.
 				case SLIME_WIFI_SERVER_CRED_G_ATTEMPT:  // Or if couldn't connect with
 														// server-sent credentials
-                    // Return to the default PHY Mode N.
-                    #if ESP8266
-                        #if USE_ATTENUATION
-					WiFi.setOutputPower(20.0 - ATTENUATION_N);
-                        #endif
-                        WiFi.setPhyMode(WIFI_PHY_MODE_11N);
-                    #endif
                     // Start smart config
 					if (!hadWifi && !WiFi.smartConfigDone()
 						&& wifiConnectionTimeout + 11000 < millis()) {

--- a/src/sensorinterface/I2CPCAInterface.cpp
+++ b/src/sensorinterface/I2CPCAInterface.cpp
@@ -32,9 +32,7 @@ void SlimeVR::I2CPCASensorInterface::swapIn() {
 	Wire.beginTransmission(m_Address);
 	Wire.write(1 << m_Channel);
 	Wire.endTransmission();
-#if ESP32
 	// On ESP32 we need to reconnect to I2C bus for some reason
 	m_Wire.disconnect();
 	m_Wire.swapIn();
-#endif
 }

--- a/src/sensorinterface/I2CWireSensorInterface.cpp
+++ b/src/sensorinterface/I2CWireSensorInterface.cpp
@@ -25,9 +25,7 @@
 
 #include <optional>
 
-#if ESP32
 #include "driver/i2c.h"
-#endif
 
 std::optional<uint8_t> activeSCLPin;
 std::optional<uint8_t> activeSDAPin;
@@ -37,7 +35,6 @@ namespace SlimeVR {
 void swapI2C(uint8_t sclPin, uint8_t sdaPin) {
 	if (sclPin != activeSCLPin || sdaPin != activeSDAPin || !isI2CActive) {
 		Wire.flush();
-#if ESP32
 		if (!isI2CActive) {
 			// Reset HWI2C to avoid being affected by I2CBUS reset
 			Wire.end();
@@ -55,9 +52,6 @@ void swapI2C(uint8_t sclPin, uint8_t sdaPin) {
 			Wire.begin(static_cast<int>(sdaPin), static_cast<int>(sclPin), I2C_SPEED);
 			Wire.setTimeOut(150);
 		}
-#else
-		Wire.begin(static_cast<int>(sdaPin), static_cast<int>(sclPin));
-#endif
 
 		activeSCLPin = sclPin;
 		activeSDAPin = sdaPin;
@@ -68,8 +62,6 @@ void swapI2C(uint8_t sclPin, uint8_t sdaPin) {
 void disconnectI2C() {
 	Wire.flush();
 	isI2CActive = false;
-#if ESP32
 	Wire.end();
-#endif
 }
 }  // namespace SlimeVR

--- a/src/sensors/ADCResistanceSensor.cpp
+++ b/src/sensors/ADCResistanceSensor.cpp
@@ -26,15 +26,9 @@
 
 namespace SlimeVR::Sensors {
 void ADCResistanceSensor::motionLoop() {
-#if ESP8266
-	float voltage = ((float)analogRead(m_Pin)) * ADCVoltageMax / ADCResolution;
-	m_Data = m_ResistanceDivider
-		   * (ADCVoltageMax / voltage - 1.0f);  // Convert voltage to resistance
-#elif ESP32
 	float voltage = ((float)analogReadMilliVolts(m_Pin)) / 1000;
 	m_Data = m_ResistanceDivider
 		   * (m_VCC / voltage - 1.0f);  // Convert voltage to resistance
-#endif
 }
 
 void ADCResistanceSensor::sendData() {

--- a/src/sensors/SensorBuilder.h
+++ b/src/sensors/SensorBuilder.h
@@ -74,9 +74,7 @@
 #define SFCALIBRATOR SlimeVR::Sensor::SoftfusionCalibrator
 #endif
 
-#if ESP32
 #include "driver/i2c.h"
-#endif
 
 namespace SlimeVR::Sensors {
 using SoftFusionLSM6DS3TRC

--- a/src/sensors/SensorFusion.h
+++ b/src/sensors/SensorFusion.h
@@ -146,9 +146,7 @@ protected:
 	sensor_real_t vecGravity[3]{0.0f, 0.0f, 0.0f};
 	bool linaccelReady = false;
 	sensor_real_t linAccel[3]{0.0f, 0.0f, 0.0f};
-#if ESP32
 	sensor_real_t linAccel_guard;  // Temporary patch for some weird ESP32 bug
-#endif
 };
 }  // namespace Sensors
 }  // namespace SlimeVR

--- a/src/sensors/SensorFusionDMP.h
+++ b/src/sensors/SensorFusionDMP.h
@@ -37,9 +37,7 @@ protected:
 	sensor_real_t vecGravity[3]{0.0f, 0.0f, 0.0f};
 	bool linaccelReady = false;
 	sensor_real_t linAccel[3]{0.0f, 0.0f, 0.0f};
-#if ESP32
 	sensor_real_t linAccel_guard;  // Temporary patch for some weird ESP32 bug
-#endif
 };
 }  // namespace Sensors
 }  // namespace SlimeVR

--- a/src/sensors/icm20948sensor.cpp
+++ b/src/sensors/icm20948sensor.cpp
@@ -169,18 +169,8 @@ void ICM20948Sensor::startCalibrationAutoSave() {
 }
 
 void ICM20948Sensor::startDMP() {
-#ifdef ESP32
-#if ESP32C3
 #define ICM20948_ODRGYR 1
 #define ICM20948_ODRAXL 1
-#else
-#define ICM20948_ODRGYR 1
-#define ICM20948_ODRAXL 1
-#endif
-#else
-#define ICM20948_ODRGYR 1
-#define ICM20948_ODRAXL 1
-#endif
 
 	if (imu.initializeDMP() == ICM_20948_Stat_Ok) {
 		m_Logger.debug("DMP initialized");

--- a/src/serial/serialcommands.cpp
+++ b/src/serial/serialcommands.cpp
@@ -31,9 +31,7 @@
 #include "logging/Logger.h"
 #include "utils.h"
 
-#if ESP32
 #include "nvs_flash.h"
-#endif
 
 namespace SerialCommands {
 SlimeVR::Logging::Logger logger("SerialCommands");
@@ -172,7 +170,6 @@ void printState() {
 	);
 }
 
-#if ESP32
 String getEncryptionTypeName(wifi_auth_mode_t type) {
 	switch (type) {
 		case WIFI_AUTH_OPEN:
@@ -196,21 +193,6 @@ String getEncryptionTypeName(wifi_auth_mode_t type) {
 		case WIFI_AUTH_WPA3_ENT_192:
 			return "WPA3_ENT_192";
 	}
-#else
-String getEncryptionTypeName(uint8_t type) {
-	switch (type) {
-		case ENC_TYPE_NONE:
-			return "OPEN";
-		case ENC_TYPE_WEP:
-			return "WEP";
-		case ENC_TYPE_TKIP:
-			return "WPA_PSK";
-		case ENC_TYPE_CCMP:
-			return "WPA2_PSK";
-		case ENC_TYPE_AUTO:
-			return "WPA_WPA2_PSK";
-	}
-#endif
 	return "UNKNOWN";
 }
 
@@ -351,15 +333,8 @@ void cmdFactoryReset(CmdParser* parser) {
 	configuration.reset();
 
 	WiFi.disconnect(true);  // Clear WiFi credentials
-#if ESP8266
-	ESP.eraseConfig();  // Clear ESP config
-#elif ESP32
+
 	nvs_flash_erase();
-#else
-#warning SERIAL COMMAND FACTORY RESET NOT SUPPORTED
-	logger.info("FACTORY RESET NOT SUPPORTED");
-	return;
-#endif
 
 #if defined(WIFI_CREDS_SSID) && defined(WIFI_CREDS_PASSWD)
 #warning FACTORY RESET does not clear your hardcoded WiFi credentials!


### PR DESCRIPTION
# Reduce complexity and improve performances

## Description of the feature

This pull request concerns two commits:
- Improved Orion Tracker performance by reducing code complexity
- Setting the "power saving mode" to None

After a few tests (see below), the overall experience is better, with improved performance:
- Fewer tracking losses
- Better range
- Slight battery usage increase

**In general, by removing if/else conditions that do not apply to ESP32 boards (those used by Orion Trackers), assuming that this code does not apply to anything other than Orion Trackers.**

**Also, setting the "power saving mode" to None, will improve network performance by reducing WiFi communication latency, at the expense of slightly higher battery usage.**

## How to test it

Use the Trackers as usual.

## Description of tests performed

Initially, we will use the latest firmware on the Trackers, using the repository tool: <https://github.com/SomaticVR/SomaticVR-Eros-Flasher>
The firmware used during testing is 0.7.2-Orion-1.

Next, we will repeat the tests using the firmware flashed from this branch, using the PlatformIO plugin for Visual Studio Code.
Note: the "platformio.ini" file used has been fixed in the "fix-platformio-build" branch.

We will load the trackers to full capacity for each tests (assuming charging is done when LEDs are not blinking when charging).

We will play a session of "Just Dance" in VRChat, in the "Just Dance VRChat" world created by "Ikbenmathijs" for exactly 1 hour for each tests, using the same musics for each tests (and so the same movements).

The results are obtained using an Alfa Network AWUS036NH antenna, by creating a Wi-Fi hotspot from Windows 11.

### Result of the tests

#### Battery

<img width="1024" height="574" alt="2026-01-27 13_52_58-Greenshot bak" src="https://github.com/user-attachments/assets/7e5de8ea-0424-4f7f-bf2b-d81e485f91b4" />

We can see that the current branch use more battery usage, but it's still acceptable.

##### 0.7.2-Orion-1

Right foot: 84% 3.99V
Right ankle: 88% 4.03V
Left ankle: 86% 4.01V
Left foot:  84% 3.99V
Right tight: 88% 4.03V
Left tight: 87% 4.02V
Chest: 87% 4.02V
Hip: 86% 4.01V
Left upper arm:  89% 4.04V
Right upper arm:  88% 4.03V

##### This branch

Right foot: 83% 3.97V
Right ankle: 86% 4.01V
Left ankle: 85% 4.00V
Left foot: 82% 3.97V
Right tight: 86% 4.01V
Left tight: 85% 4.00V
Chest: 84% 3.98V
Hip: 82% 3.97V
Left upper arm: 87% 4.02V
Right upper arm: 86% 4.01V

#### Average response time

<img width="1024" height="572" alt="2026-01-27 14_10_18-Greenshot bak" src="https://github.com/user-attachments/assets/65a345bc-ead9-4684-bfdd-a6d720639722" />

We can see that average response time is better for some parts of the body (maybe because of the movements), and still the same for some other parts.

##### 0.7.2-Orion-1

Right foot:  8 ms
Right ankle:  11 ms
Left ankle:  10 ms
Left foot:  11 ms
Right tight: 9 ms
Left tight: 16 ms
Chest: 12 ms
Hip:  10 ms
Left upper arm: 14 ms
Right upper arm: 11 ms

##### This branch

Right foot:  8 ms
Right ankle:  9 ms
Left ankle:  10 ms
Left foot:  7 ms
Right tight: 8 ms
Left tight: 11 ms
Chest: 12 ms
Hip:  6 ms
Left upper arm: 14 ms
Right upper arm: 10 ms

## Checklist

Please check if your merge request fulfills the following requirements:

- [X] Tests was made, and any changes were pushed.
- [ ] Unit tests have been added, if needed.
- [X] Branch has been rebased (see <https://git-scm.com/docs/git-rebase>) from the source branch.
- [ ] Documentation has been updated, if needed.
- [X] Lint has passed, and most of the errors have been corrected, if possible.

/label ~Feature